### PR TITLE
Add objPath support to Python SDK

### DIFF
--- a/atk_python_sdk_test.py
+++ b/atk_python_sdk_test.py
@@ -7,47 +7,47 @@ if __name__ == "__main__":
     atkOpen(base, "127.0.0.1", 6655)
 
     # 创建场景、设置场景时间
-    atkConnect(base, "New", "/ Scenario SimpleScenario")
-    atkConnect(base, "SetAnalysisTimePeriod", '* "1 Jan 2025 00:00:00.000" "5 Jan 2025 00:00:00.000"')
-    atkConnect(base, "Animate", "* Reset")
+    atkConnect(base, "New", "/", "Scenario SimpleScenario")
+    atkConnect(base, "SetAnalysisTimePeriod", "*", '"1 Jan 2025 00:00:00.000" "5 Jan 2025 00:00:00.000"')
+    atkConnect(base, "Animate", "*", "Reset")
 
     # 使用 TLE 创建卫星
     tle1 = "1 99001U 25001A   25197.00000000  .00001200  00000-0  90000-4 0  9997"
     tle2 = "2 99001  97.4000  45.0000 0009000  90.0000 270.0000 13.20000000  1000"
-    atkConnect(base, "New", "/ Satellite sat_tle")
-    atkConnect(base, "SetState", f'*/Satellite/sat_tle TLE "{tle1}" "{tle2}"')
-    atkConnect(base, "Graphics", f'*/Satellite/sat_tle SetColor {color_num}')
+    atkConnect(base, "New", "/", "Satellite sat_tle")
+    atkConnect(base, "SetState", "*/Satellite/sat_tle", f'TLE "{tle1}" "{tle2}"')
+    atkConnect(base, "Graphics", "*/Satellite/sat_tle", f'SetColor {color_num}')
     color_num = color_num + 1
-    atkConnect(base, "Animate", "* Reset")
+    atkConnect(base, "Animate", "*", "Reset")
 
 
     # 使用 轨道六根数 创建卫星
-    atkConnect(base, "New", "/ Satellite sat_para")
-    atkConnect(base, "SetState", '*/Satellite/sat_para Classical TwoBody "1 Jan 2025 00:00:00.000" "5 Jan 2025 00:00:00.000" 60 J2000 "1 Jan 2025 00:00:00.000" 6678137 0 28.5 0 0 0')
-    atkConnect(base, "Graphics", f'*/Satellite/sat_para SetColor {color_num}')
+    atkConnect(base, "New", "/", "Satellite sat_para")
+    atkConnect(base, "SetState", '*/Satellite/sat_para', 'Classical TwoBody "1 Jan 2025 00:00:00.000" "5 Jan 2025 00:00:00.000" 60 J2000 "1 Jan 2025 00:00:00.000" 6678137 0 28.5 0 0 0')
+    atkConnect(base, "Graphics", "*/Satellite/sat_para", f'SetColor {color_num}')
     color_num = color_num + 1
-    atkConnect(base, "Animate", "* Reset")
+    atkConnect(base, "Animate", "*", "Reset")
 
     # 创建地面站
-    atkConnect(base, "New", "/ Facility GroundStation1")
-    atkConnect(base, "SetPosition", "*/Facility/GroundStation1 Geodetic 39.9 116.4 50.0")
-    atkConnect(base, "Graphics", f'*/Facility/GroundStation1 SetColor {color_num}')
+    atkConnect(base, "New", "/", "Facility GroundStation1")
+    atkConnect(base, "SetPosition", "*/Facility/GroundStation1", "Geodetic 39.9 116.4 50.0")
+    atkConnect(base, "Graphics", "*/Facility/GroundStation1", f'SetColor {color_num}')
     color_num = color_num + 1
-    atkConnect(base, "SetConstraint", '*/Facility/GroundStation1 AzimuthAngle Min -180.0 Max 180.0 ExcludeIntervals')
-    atkConnect(base, "SetConstraint", '*/Facility/GroundStation1 ElevationAngle Min -90.0 Max 90.0 ExcludeIntervals')
-    atkConnect(base, "Animate", "* Reset")
+    atkConnect(base, "SetConstraint", "*/Facility/GroundStation1", 'AzimuthAngle Min -180.0 Max 180.0 ExcludeIntervals')
+    atkConnect(base, "SetConstraint", "*/Facility/GroundStation1", 'ElevationAngle Min -90.0 Max 90.0 ExcludeIntervals')
+    atkConnect(base, "Animate", "*", "Reset")
 
     # 创建地面站传感器
-    atkConnect(base, "New", "/ Facility/GroundStation1/Sensor Sensor1")
-    atkConnect(base, "Define", "*/Facility/GroundStation1/Sensor/Sensor1 Rectangular 25.1 36.8")
-    atkConnect(base, "Point", '*/Facility/GroundStation1/Sensor/Sensor1 Fixed Euler 121 180.0 0.0 0.0')
-    atkConnect(base, "Graphics", f'*/Facility/GroundStation1/Sensor/Sensor1 SetColor {color_num}')
+    atkConnect(base, "New", "/", "Facility/GroundStation1/Sensor Sensor1")
+    atkConnect(base, "Define", "*/Facility/GroundStation1/Sensor/Sensor1", "Rectangular 25.1 36.8")
+    atkConnect(base, "Point", '*/Facility/GroundStation1/Sensor/Sensor1', 'Fixed Euler 121 180.0 0.0 0.0')
+    atkConnect(base, "Graphics", '*/Facility/GroundStation1/Sensor/Sensor1', f'SetColor {color_num}')
     color_num = color_num + 1
-    atkConnect(base, "Animate", "* Reset")
+    atkConnect(base, "Animate", "*", "Reset")
 
     # 获取可见性报告
-    atkConnect(base, "Report_RM", '*/Facility/GroundStation1/Sensor/Sensor1 Style "Access" Type Display AccessObject */Satellite/sat_para TimePeriod "1 Jan 2025 00:00:00.000" "5 Jan 2025 00:00:00.000"')
-    atkConnect(base, "Report_RM", '*/Facility/GroundStation1/Sensor/Sensor1 Style "Access" Type Display AccessObject */Satellite/sat_tle TimePeriod "1 Jan 2025 00:00:00.000" "5 Jan 2025 00:00:00.000"')
+    atkConnect(base, "Report_RM", '*/Facility/GroundStation1/Sensor/Sensor1', 'Style "Access" Type Display AccessObject */Satellite/sat_para TimePeriod "1 Jan 2025 00:00:00.000" "5 Jan 2025 00:00:00.000"')
+    atkConnect(base, "Report_RM", '*/Facility/GroundStation1/Sensor/Sensor1', 'Style "Access" Type Display AccessObject */Satellite/sat_tle TimePeriod "1 Jan 2025 00:00:00.000" "5 Jan 2025 00:00:00.000"')
 
     # 关闭 ATK
     atkClose(base)

--- a/tests/test_atk_python_sdk.py
+++ b/tests/test_atk_python_sdk.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock, patch
+import os, sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from atk_python_sdk import atkConnect
+
+
+def test_atkConnect_includes_objPath():
+    with patch("atk_python_sdk.requests.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"events": ["ok"]}
+        mock_resp.content = b'{"events":["ok"]}'
+        mock_post.return_value = mock_resp
+
+        events = atkConnect("http://example", "New", "/", "Scenario Test")
+
+        assert events == ["ok"]
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"] == {
+            "command": "New",
+            "objPath": "/",
+            "cmdParam": "Scenario Test",
+            "waitMs": 10,
+        }


### PR DESCRIPTION
## Summary
- include objPath parameter in atkConnect and send it with commands
- update example script to new signature
- add unit test covering objPath payload handling

## Testing
- `pytest -q`
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0394fd34832f93dbc216cf4a51a9