### PR TITLE
feat: include ATKConnectorTools jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,18 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>ATKConnectorTools</artifactId>
+            <version>1.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/ATKConnectorTools.jar</systemPath>
+        </dependency>
     </dependencies>
 
     <build>
+        <finalName>atk_python_sdk_service</finalName>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- include ATKConnectorTools.jar as a system dependency
- set packaged jar name to atk_python_sdk_service

## Testing
- `mvn -q test` *(fails: could not resolve parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac068fb9e4832fb212da91ab168db7